### PR TITLE
Fix context commands

### DIFF
--- a/src/main/kotlin/de/mineking/discord/commands/CommandImpl.kt
+++ b/src/main/kotlin/de/mineking/discord/commands/CommandImpl.kt
@@ -2,6 +2,7 @@ package de.mineking.discord.commands
 
 import de.mineking.discord.localization.LocalizationFile
 import net.dv8tion.jda.api.entities.IMentionable
+import net.dv8tion.jda.api.interactions.DiscordLocale
 import net.dv8tion.jda.api.interactions.IntegrationType
 import net.dv8tion.jda.api.interactions.InteractionContextType
 import net.dv8tion.jda.api.interactions.commands.Command.Type
@@ -100,9 +101,18 @@ abstract class ContextCommandImpl<C : ContextCommandContext<*, *>>(
 ) : CommandImpl<C, CommandData>(name, null, localization, setup, conditions, defaultMemberPermissions, contexts, types) {
     override fun build(manager: CommandManager): CommandData {
         val localization = manager.localization?.getCommandDescription(effectiveLocalization(), this)
-        val result = Commands.context(type, localization?.default ?: name)
+        val result = Commands.context(type, name)
 
-        if (localization != null) result.setNameLocalizations(localization.localization)
+        if (localization != null) {
+            // Context commands don't have a localized fallback, so we need to provide a localized value for every locale
+            val values = localization.localization.toMutableMap()
+            DiscordLocale.entries.forEach {
+                if (it == DiscordLocale.UNKNOWN) return@forEach
+                values.putIfAbsent(it, localization.default)
+            }
+
+            result.setNameLocalizations(values)
+        }
         finalize(result)
 
         return result

--- a/src/main/kotlin/de/mineking/discord/commands/CommandManager.kt
+++ b/src/main/kotlin/de/mineking/discord/commands/CommandManager.kt
@@ -2,6 +2,7 @@ package de.mineking.discord.commands
 
 import de.mineking.discord.DiscordToolKit
 import de.mineking.discord.Manager
+import mu.KotlinLogging
 import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.GenericCommandInteractionEvent
 import net.dv8tion.jda.api.events.interaction.command.MessageContextInteractionEvent
@@ -13,6 +14,8 @@ import net.dv8tion.jda.api.interactions.commands.build.CommandData
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.kotlinProperty
 import kotlin.reflect.typeOf
+
+private val logger = KotlinLogging.logger {}
 
 @DslMarker
 annotation class CommandMarker
@@ -134,6 +137,9 @@ class CommandManager internal constructor(manager: DiscordToolKit<*>) : Manager(
              .map { it.build(this) }
         )//.apply { entryPoint?.build(this@CommandManager)?.let { setPrimaryEntryPointCommand(it) } }
         .onSuccess { result -> result.forEach {
-            getCommand(it.fullCommandName)!!.idLong = it.idLong
+            val command = getCommand(it.fullCommandName)
+                ?: return@onSuccess logger.warn("Command update response contained unknown command '${it.fullCommandName}'")
+
+            command.idLong = it.idLong
         } }
 }

--- a/src/main/kotlin/de/mineking/discord/commands/Localization.kt
+++ b/src/main/kotlin/de/mineking/discord/commands/Localization.kt
@@ -26,7 +26,7 @@ class DefaultCommandLocalizationHandler(val prefix: String, val args: Map<String
         val default = if (command is SlashCommandImpl) command.description else command.name
         if (file == null) return LocalizationInfo(default)
 
-        val key = default.takeIf { it != DEFAULT_COMMAND_DESCRIPTION } ?: "${command.path()}.description"
+        val key = default.takeIf { command is SlashCommandImpl && it != DEFAULT_COMMAND_DESCRIPTION } ?: "${command.path()}.description"
         return createLocalization(file, command, key)
     }
 


### PR DESCRIPTION
Context command localization and handling was broken because the localized name would be used as internal name, causing identification errors.